### PR TITLE
Amend genson version to 1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
     <javax.interceptor-api.version>1.2.2</javax.interceptor-api.version>
     <cdi-api.version>2.0.SP1</cdi-api.version>
     <javax.ws.rs-api.version>2.1.1</javax.ws.rs-api.version>
-    <genson.version>2.1.1</genson.version>
+    <genson.version>1.6</genson.version>
     <hamcrest-date.version>2.0.7</hamcrest-date.version>
     <modelmapper.version>2.3.7</modelmapper.version>
     <jxls.version>2.8.1</jxls.version>


### PR DESCRIPTION
设置的 com.owlike:genson 版本有误，
在 https://search.maven.org/search?q=genson 查询的依赖版本号最高为 1.6。

在项目 bc-identity 中看到 com.owlike:genson 使用依赖版本是 1.3，
为防止版本之间兼容问题，更改 2.1.1 为 1.3.