### PR TITLE
Amend genson version to 1.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
     <javax.interceptor-api.version>1.2.2</javax.interceptor-api.version>
     <cdi-api.version>2.0.SP1</cdi-api.version>
     <javax.ws.rs-api.version>2.1.1</javax.ws.rs-api.version>
-    <genson.version>2.1.1</genson.version>
+    <genson.version>1.6</genson.version>
     <hamcrest-date.version>2.0.7</hamcrest-date.version>
     <modelmapper.version>2.3.7</modelmapper.version>
     <jxls.version>2.8.1</jxls.version>


### PR DESCRIPTION
在 https://search.maven.org/search?q=genson 查询发现
com.owlike:genson 当前的最新版本是 1.6 不是 2.1.1